### PR TITLE
fix: prevent API call when city input is empty or only spaces

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
             <h3>Enter a City Name</h3>
             <!-- input box for entering the city name -->
             <input class="city-input" type="text" placeholder="E.g., New York, London, Tokyo" aria-label="City name input">
+            <div class="error-message" style="display: none;"></div>
             <button class="search-btn" aria-label="Search weather by city name">
                 <span class="btn-text">Search</span>
                 <div class="loading-spinner" style="display: none;"></div>

--- a/script.js
+++ b/script.js
@@ -261,3 +261,25 @@ document.addEventListener('DOMContentLoaded', () => {
     });
     console.log('Weather App initialized successfully!');
 });
+document.addEventListener("DOMContentLoaded", () => {
+    const searchBtn = document.querySelector(".search-btn");
+    const cityInput = document.querySelector(".city-input");
+    const errorMessage = document.querySelector(".error-message");
+
+    searchBtn.addEventListener("click", () => {
+        const city = cityInput.value.trim();
+
+        // Reset alert state
+        errorMessage.style.display = "none";
+        errorMessage.textContent = "";
+
+        if (city === "") {
+            errorMessage.textContent = "⚠️ Please enter a city name before searching.";
+            errorMessage.style.display = "block";
+            return;
+        }
+
+        // Continue to fetch weather data
+        fetchWeatherData(city); // your API call
+    });
+});

--- a/style.css
+++ b/style.css
@@ -325,3 +325,21 @@ input:checked + .slider:before {
         flex-direction: column; /* Stack cards vertically */
     }
 }
+.error-message {
+    color: red;
+    font-size: 14px;
+    margin-top: 10px;
+}
+
+.error-message {
+    display: none;
+    background-color: #ffe0e0;  /* soft red background */
+    color: #a94442;             /* dark red text */
+    border: 1px solid #f5c6cb;
+    padding: 8px 12px;
+    margin: 8px 0;
+    border-radius: 5px;
+    font-size: 14px;
+    font-weight: 500;
+}
+


### PR DESCRIPTION
This PR adds a simple input validation check to prevent unnecessary API calls when the city input is empty or contains only spaces.
It improves the user experience by stopping the getCityCoordinates() function if the input is not valid.